### PR TITLE
Fix bug in transport_tcp

### DIFF
--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -311,9 +311,10 @@ bool TransportTCP::connect(const std::string& host, int port)
 
   int ret = ::connect(sock_, (sockaddr*) &sas, sas_len);
   // windows might need some time to sleep (input from service robotics hack) add this if testing proves it is necessary.
-  ROS_ASSERT((flags_ & SYNCHRONOUS) || ret != 0);
+  // ROS_ASSERT((flags_ & SYNCHRONOUS) || ret != 0);
   if (((flags_ & SYNCHRONOUS) && ret != 0) || // synchronous, connect() should return 0
-      (!(flags_ & SYNCHRONOUS) && last_socket_error() != ROS_SOCKETS_ASYNCHRONOUS_CONNECT_RETURN)) // asynchronous, connect() should return -1 and WSAGetLastError()=WSAEWOULDBLOCK/errno=EINPROGRESS
+      (!(flags_ & SYNCHRONOUS) && // asynchronous, connect() may return 0 or -1. When return -1, WSAGetLastError()=WSAEWOULDBLOCK/errno=EINPROGRESS
+      (ret != 0 && last_socket_error() != ROS_SOCKETS_ASYNCHRONOUS_CONNECT_RETURN))) 
   {
     ROSCPP_CONN_LOG_DEBUG("Connect to tcpros publisher [%s:%d] failed with error [%d, %s]", host.c_str(), port, ret, last_socket_error_string());
     close();


### PR DESCRIPTION
Fix about [Subscribing & Publishing from ROS nodes does not work · Issue #1391 · Microsoft/BashOnWindows](https://github.com/Microsoft/BashOnWindows/issues/1391)

Line 316 in [ros_comm/roscpp/src/libros/transport/transport_tcp.cpp](http://docs.ros.org/kinetic/api/roscpp/html/transport__tcp_8cpp_source.html)


```
  312   int ret = ::connect(sock_, (sockaddr*) &sas, sas_len);
  313   // windows might need some time to sleep (input from service robotics hack) add this if testing proves it is necessary.
  314   ROS_ASSERT((flags_ & SYNCHRONOUS) || ret != 0);
  315   if (((flags_ & SYNCHRONOUS) && ret != 0) || // synchronous, connect() should return 0
  316       (!(flags_ & SYNCHRONOUS) && last_socket_error() != ROS_SOCKETS_ASYNCHRONOUS_CONNECT_RETURN)) // asynchronous, connect() should return -1 and WSAGetLastError()=WSAEWOULDBLOCK/errno=EINPROGRESS
  317   {
  318     ROSCPP_CONN_LOG_DEBUG("Connect to tcpros publisher [%s:%d] failed with error [%d, %s]", host.c_str(), port, ret, last_socket_error_string());
  319     close();
  320 
  321     return false;
  322   }
```
It assumes that the `connect` method of non-blocking scoket should return -1 and `last_socket_error()` should return `ROS_SOCKETS_ASYNCHRONOUS_CONNECT_RETURN`(=`EINPROGRESS`). 
But a non-blocking `connect` can return 0 when TCP connection to 127.0.0.1 (localhost).
[http://stackoverflow.com/questions/14027326/can-connect-return-0-with-non-blocing-socket](http://stackoverflow.com/questions/14027326/can-connect-return-0-with-non-blocing-socket)

In Bash on Ubuntu on Windows, when connecting to 127.0.1.1 non-blocking, it returns 0 which raise an error 
 `[WARN] [1479567965.827686]: Inbound TCP/IP connection failed: connection from sender terminated before handshake header received. 0 bytes were received. Please check sender for additional details.`

After patch, topic tests successfully in [ROS/Tutorials/WritingPublisherSubscriber(python)](http://wiki.ros.org/ROS/Tutorials/WritingPublisherSubscriber%28python%29),  [ROS/Tutorials/ExaminingPublisherSubscriber](http://wiki.ros.org/ROS/Tutorials/ExaminingPublisherSubscriber) and [turtlesim](http://wiki.ros.org/ROS/Tutorials/UnderstandingTopics)